### PR TITLE
fix incorrect display of short locale

### DIFF
--- a/src/services/locales/en/common.json
+++ b/src/services/locales/en/common.json
@@ -1,6 +1,7 @@
 {
 	"locale": {
-		"long": "en-GB"
+		"long": "en-GB",
+		"short": "EN"
 	},
 	"details": "Details",
 	"home": "Home",

--- a/src/services/locales/es/common.json
+++ b/src/services/locales/es/common.json
@@ -1,6 +1,7 @@
 {
 	"locale": {
-		"long": "es-ES"
+		"long": "es-ES",
+		"short": "ES"
 	},
 	"details": "Detalles",
 	"home": "Inicio",

--- a/src/services/locales/eu/common.json
+++ b/src/services/locales/eu/common.json
@@ -1,6 +1,7 @@
 {
 	"locale": {
-		"long": "es-ES"
+		"long": "es-ES",
+		"short": "EU"
 	},
 	"details": "Xehetasunak",
 	"home": "Hasiera",


### PR DESCRIPTION
It seems short name of local is missing from common.json which causes the short name displayed incorrectly.


<img width="298" alt="Screenshot" src="https://github.com/user-attachments/assets/187f8027-8a50-498a-a777-ed0f81a28315" />
